### PR TITLE
Manual installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,11 @@ git+https://github.com/TheDJVG/netbox-field-permissions
 Enable the plugin in `/opt/netbox/netbox/netbox/configuration.py`,
 or if you use netbox-docker, your `/configuration/plugins.py` file :
 
-
+```python
+PLUGINS = [
+    'netbox_field_permissions'
+]
+```
 
 ### Validator installation
 By default, the migration will install the validator for all models. If you're using a statically configured NetBox

--- a/README.md
+++ b/README.md
@@ -47,11 +47,354 @@ git+https://github.com/TheDJVG/netbox-field-permissions
 Enable the plugin in `/opt/netbox/netbox/netbox/configuration.py`,
 or if you use netbox-docker, your `/configuration/plugins.py` file :
 
+
+
+### Validator installation
+By default, the migration will install the validator for all models. If you're using a statically configured NetBox
+instance you can use this `CUSTOM_VALIDATORS` block to install it for all models:
+<details>
+<summary>Show configuration snippet</summary>
+
 ```python
-PLUGINS = [
-    'netbox_field_permissions'
-]
+CUSTOM_VALIDATORS = {
+    "circuits.circuit": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "circuits.circuittermination": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "circuits.circuittype": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "circuits.provider": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "circuits.provideraccount": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "circuits.providernetwork": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.cable": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.cablepath": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.cabletermination": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.consoleport": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.consoleporttemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.consoleserverport": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.consoleserverporttemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.device": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.devicebay": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.devicebaytemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.devicerole": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.devicetype": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.frontport": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.frontporttemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.interface": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.interfacetemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.inventoryitem": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.inventoryitemrole": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.inventoryitemtemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.location": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.manufacturer": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.module": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.modulebay": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.modulebaytemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.moduletype": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.platform": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.powerfeed": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.poweroutlet": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.poweroutlettemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.powerpanel": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.powerport": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.powerporttemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.rack": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.rackreservation": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.rackrole": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.rearport": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.rearporttemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.region": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.site": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.sitegroup": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.virtualchassis": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "dcim.virtualdevicecontext": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.bookmark": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.branch": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.cachedvalue": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.configcontext": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.configtemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.customfield": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.customfieldchoiceset": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.customlink": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.dashboard": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.eventrule": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.exporttemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.imageattachment": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.journalentry": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.objectchange": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.reportmodule": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.savedfilter": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.script": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.scriptmodule": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.stagedchange": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.tag": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.taggeditem": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "extras.webhook": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.aggregate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.asn": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.asnrange": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.fhrpgroup": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.fhrpgroupassignment": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.ipaddress": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.iprange": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.prefix": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.rir": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.role": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.routetarget": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.service": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.servicetemplate": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.vlan": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.vlangroup": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "ipam.vrf": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "tenancy.contact": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "tenancy.contactassignment": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "tenancy.contactgroup": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "tenancy.contactrole": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "tenancy.tenant": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "tenancy.tenantgroup": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "virtualization.cluster": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "virtualization.clustergroup": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "virtualization.clustertype": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "virtualization.virtualdisk": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "virtualization.virtualmachine": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "virtualization.vminterface": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.ikepolicy": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.ikeproposal": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.ipsecpolicy": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.ipsecprofile": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.ipsecproposal": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.l2vpn": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.l2vpntermination": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.tunnel": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.tunnelgroup": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "vpn.tunneltermination": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "wireless.wirelesslan": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "wireless.wirelesslangroup": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ],
+    "wireless.wirelesslink": [
+        "netbox_field_permissions.validators.FieldPermissionValidator"
+    ]
+}
 ```
+</details>
+
+You can also view updated configuration on the `Plugins -> Field Permissions -> Manage Validator` page.
 
 ## Features
 

--- a/netbox_field_permissions/migrations/0001_initial.py
+++ b/netbox_field_permissions/migrations/0001_initial.py
@@ -34,7 +34,8 @@ def get_current_config(apps):
 def write_static_configuration_messsage():
     sys.stdout.write(
         colorize(
-            "\n  Static NetBox configuration detected. Please install customer validator manually!!",
+            "\n  Static NetBox configuration detected. Please install plugin validator manually by "
+            "adding 'netbox_field_permissions.validators.FieldPermissionValidator' for each model.",
             fg="yellow",
             opts=("bold",),
         )

--- a/netbox_field_permissions/navigation.py
+++ b/netbox_field_permissions/navigation.py
@@ -10,7 +10,7 @@ menu_items = (
                 title="Add",
                 icon_class="mdi mdi-plus-thick",
                 permissions=("netbox_field_permissions.add_fieldpermission",),
-            )
+            ),
         ],
     ),
 )

--- a/netbox_field_permissions/templates/netbox_field_permissions/fieldpermission_list.html
+++ b/netbox_field_permissions/templates/netbox_field_permissions/fieldpermission_list.html
@@ -1,7 +1,7 @@
 {% extends "generic/object_list.html" %}
 
 {% block extra_controls %}
-{% if user.is_superuser %}
+{% if user.is_staff %}
 <a href="{% url 'plugins:netbox_field_permissions:fieldpermission_manage' %}" class="btn btn-secondary" type="button">
     <i class="mdi mdi-cog" aria-hidden="true"></i> Manage Validators</a>
 {% endif %}

--- a/netbox_field_permissions/templates/netbox_field_permissions/manage.html
+++ b/netbox_field_permissions/templates/netbox_field_permissions/manage.html
@@ -1,4 +1,5 @@
 {% extends 'generic/_base.html' %}
+{% load helpers %}
 {% load render_table from django_tables2 %}
 {% block title %}Manage Field Permission Plugin{% endblock title %}
 {% block subtitle %}
@@ -6,17 +7,70 @@
 {% endblock subtitle %}
 
 {% block control-buttons %}
+{% if not validators_statically_configured %}
 <form action="" method="post">
     {% csrf_token %}
     <button type="submit" name="_install" class="btn btn-success">
-        <i class="mdi mdi-check" aria-hidden="true"></i> Install validators</button>
+        <i class="mdi mdi-check" aria-hidden="true"></i> Install validators
+    </button>
     <button type="submit" name="_uninstall" class="btn btn-danger">
-        <i class="mdi mdi-cancel" aria-hidden="true"></i> Remove validators</button>
+        <i class="mdi mdi-cancel" aria-hidden="true"></i> Remove validators
+    </button>
 </form>
+{% endif %}
 {% endblock %}
+
+
+{% block tabs %}
+{% if validators_statically_configured %}
+  <ul class="nav nav-tabs" role="presentation">
+    {# Primary tab #}
+    <li class="nav-item">
+      <a class="nav-link{% if not show_manual_install %} active{% endif %}" href="{% url 'plugins:netbox_field_permissions:fieldpermission_manage' %}">Configuration status</a>
+    </li>
+      <li class="nav-item">
+      <a class="nav-link{% if show_manual_install %} active{% endif %}"  href="{% url 'plugins:netbox_field_permissions:fieldpermission_manage' %}?manual_install">Manual configuration</a>
+    </li>
+  </ul>
+{% endif %}
+{% endblock tabs %}
 
 {% block content %}
 <div class="row">
+    {% if validators_statically_configured %}
+        <div class="alert alert-warning" role="alert">
+        <h4 class="alert-title">Static NetBox configuration detected</h4>
+        <p>Your NetBox configuration is statically configured. This means the plugin can not manage the validators
+            automatically or at user request. You can still manually add/remove the validators to your configuration using the prepared configuration <a href="{% url 'plugins:netbox_field_permissions:fieldpermission_manage' %}?manual_install">here</a>. The validator is required to check the fields a user/group has access to.</p>
+        <p>If you want to switch to a dynamic configuration please consult the NetBox documentation on config revisions.</p>
+    </div>
+    {% endif %}
+    {% if show_manual_install %}
+    <div class="col col-md-6">
+        <div class="card">
+            <h2 class="card-header">Install custom validator</h2>
+            <div class="card-body">
+                {% spaceless %}
+                <pre class="change-data">
+                    <span>CUSTOM_VALIDATORS = {{ install_validators|json }}</span>
+                </pre>
+                {% endspaceless %}
+            </div>
+        </div>
+    </div>
+    <div class="col col-md-6">
+        <div class="card">
+            <h2 class="card-header">Remove custom validator</h2>
+            <div class="card-body">
+                {% spaceless %}
+                <pre class="change-data">
+                    <span>CUSTOM_VALIDATORS = {{ uninstall_validators|json }}</span>
+                </pre>
+                {% endspaceless %}
+            </div>
+        </div>
+    </div>
+    {% else %}
     {% for app, table in tables.items %}
     <div class="col col-md-3">
         <div class="card">
@@ -27,5 +81,6 @@
         </div>
     </div>
     {% endfor %}
+    {% endif %}
 </div>
 {% endblock content %}


### PR DESCRIPTION
If you're using a dynamic NetBox configuration the validator can be
installed automatically. In the case you're using a static config the
Plugin 'Manage Validators' page will now warn you about this and provide
a configuration snippet that includes your existing validators,
including uninstall information the preserves your existing validators.